### PR TITLE
Add HTMX sidebar for single-page navigation

### DIFF
--- a/apps/accounts/templates/accounts/base.html
+++ b/apps/accounts/templates/accounts/base.html
@@ -5,18 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Barber SaaS{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <script src="https://unpkg.com/htmx.org@1.9.8"></script>
 </head>
 <body class="bg-light">
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
-  <div class="container">
-    <a class="navbar-brand" href="#">Barber SaaS</a>
-  </div>
-</nav>
-<div class="container">
-  {% for message in messages %}
-    <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-  {% endfor %}
-  {% block content %}{% endblock %}
+<div class="d-flex">
+  <nav class="bg-dark text-white p-3" style="min-height:100vh; width:220px;">
+    <h4 class="text-white">Barber SaaS</h4>
+    <ul class="nav nav-pills flex-column">
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'accounts:owner_dashboard' %}" hx-target="#content" hx-push-url="true">Dashboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'accounts:owner_login' %}" hx-target="#content" hx-push-url="true">Login</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Lojas</a>
+      </li>
+    </ul>
+  </nav>
+  <main class="flex-grow-1 p-4" id="content">
+    {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% block content %}{% endblock %}
+  </main>
 </div>
 </body>
 </html>

--- a/apps/accounts/templates/accounts/partials/owner_dashboard.html
+++ b/apps/accounts/templates/accounts/partials/owner_dashboard.html
@@ -1,0 +1,9 @@
+<h3 class="mb-3">Bem-vindo, {{ request.user.email }}</h3>
+{% if subscription %}
+  <p>Plano atual: <strong>{{ subscription.get_plan_display }}</strong></p>
+  <p>Vigência: {{ subscription.start_date|date:'d/m/Y H:i' }} até <strong>{{ subscription.end_date|date:'d/m/Y H:i' }}</strong></p>
+  <p>Status: {% if subscription.is_active %}<span class="badge bg-success">Ativa</span>{% else %}<span class="badge bg-danger">Expirada</span>{% endif %}</p>
+{% else %}
+  <div class="alert alert-warning">Sem assinatura vinculada.</div>
+{% endif %}
+<a class="btn btn-secondary" href="{% url 'accounts:owner_logout' %}">Sair</a>

--- a/apps/accounts/templates/accounts/partials/owner_login.html
+++ b/apps/accounts/templates/accounts/partials/owner_login.html
@@ -1,0 +1,11 @@
+<div class="row justify-content-center">
+  <div class="col-md-5">
+    <h3 class="mb-3">Login (Dono)</h3>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Entrar</button>
+    </form>
+    <hr>
+    <p class="text-muted small">Primeiro login cria automaticamente o período Free (7 dias).</p>
+  </div>
+</div>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -4,6 +4,7 @@ from . import views
 app_name = 'accounts'
 
 urlpatterns = [
+    path('', views.owner_login, name='home'),
     # Owner
     path('login/', views.owner_login, name='owner_login'),
     path('logout/', views.owner_logout, name='owner_logout'),

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -32,13 +32,21 @@ def owner_login(request):
             return redirect('accounts:owner_dashboard')
     else:
         form = OwnerLoginForm()
-    return render(request, 'accounts/owner_login.html', {'form': form})
+
+    template = 'accounts/owner_login.html'
+    if request.headers.get('HX-Request'):
+        template = 'accounts/partials/owner_login.html'
+    return render(request, template, {'form': form})
 
 @login_required
 def owner_dashboard(request):
     user = request.user
     sub = getattr(user, 'subscription', None)
-    return render(request, 'accounts/owner_dashboard.html', {'subscription': sub})
+
+    template = 'accounts/owner_dashboard.html'
+    if request.headers.get('HX-Request'):
+        template = 'accounts/partials/owner_dashboard.html'
+    return render(request, template, {'subscription': sub})
 
 @login_required
 def owner_logout(request):

--- a/apps/cadastro/templates/loja/partials/owner_shops.html
+++ b/apps/cadastro/templates/loja/partials/owner_shops.html
@@ -1,0 +1,32 @@
+<div class="row">
+  <div class="col-md-5">
+    <h4 class="mb-3">Nova loja</h4>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Criar loja</button>
+    </form>
+  </div>
+  <div class="col-md-7">
+    <h4 class="mb-3">Lojas cadastradas</h4>
+    <table class="table table-striped">
+      <thead><tr><th>Nome</th><th>Link público</th><th>Status</th></tr></thead>
+      <tbody>
+        {% for loja in lojas %}
+        <tr>
+          <td>{{ loja.nome }}</td>
+          <td><a href="{{ loja.get_public_url request }}" target="_blank">{{ loja.get_public_url request }}</a></td>
+          <td>
+            {% if loja.ativa %}
+              <span class="badge bg-success">Ativa</span>
+            {% else %}
+              <span class="badge bg-secondary">Inativa</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-muted">Nenhuma loja ainda.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/apps/cadastro/views.py
+++ b/apps/cadastro/views.py
@@ -19,12 +19,16 @@ def owner_shops(request):
             loja.owner = request.user
             loja.save()
             messages.success(request, 'Loja criada com sucesso!')
-            return redirect('loja:owner_shops')
+            return redirect('cadastro:owner_shops')
     else:
         form = LojaForm()
 
     lojas = request.user.lojas.all().order_by('-criada_em')
-    return render(request, 'loja/owner_shops.html', {
+
+    template = 'loja/owner_shops.html'
+    if request.headers.get('HX-Request'):
+        template = 'loja/partials/owner_shops.html'
+    return render(request, template, {
         'form': form,
         'lojas': lojas,
     })


### PR DESCRIPTION
## Summary
- integrate HTMX and a sidebar layout for SPA-like navigation
- serve partial templates for dashboard, login and shop management views
- adjust URLs and views to respond with fragments when requested via HTMX

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a3be7d9ec483329e7b49a90498a038