### PR TITLE
Add HTMX CRUD for shops, employees and services

### DIFF
--- a/apps/accounts/templates/accounts/base.html
+++ b/apps/accounts/templates/accounts/base.html
@@ -5,18 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Barber SaaS{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <script src="https://unpkg.com/htmx.org@1.9.8"></script>
 </head>
 <body class="bg-light">
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
-  <div class="container">
-    <a class="navbar-brand" href="#">Barber SaaS</a>
-  </div>
-</nav>
-<div class="container">
-  {% for message in messages %}
-    <div class="alert alert-{{ message.tags }}">{{ message }}</div>
-  {% endfor %}
-  {% block content %}{% endblock %}
+<div class="d-flex">
+  <nav class="bg-dark text-white p-3" style="min-height:100vh; width:220px;">
+    <h4 class="text-white">Barber SaaS</h4>
+    <ul class="nav nav-pills flex-column">
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'accounts:owner_dashboard' %}" hx-target="#content" hx-push-url="true">Dashboard</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'accounts:owner_login' %}" hx-target="#content" hx-push-url="true">Login</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link text-white" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Lojas</a>
+      </li>
+    </ul>
+  </nav>
+  <main class="flex-grow-1 p-4" id="content">
+    {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% block content %}{% endblock %}
+  </main>
 </div>
 </body>
 </html>

--- a/apps/accounts/templates/accounts/partials/owner_dashboard.html
+++ b/apps/accounts/templates/accounts/partials/owner_dashboard.html
@@ -1,0 +1,9 @@
+<h3 class="mb-3">Bem-vindo, {{ request.user.email }}</h3>
+{% if subscription %}
+  <p>Plano atual: <strong>{{ subscription.get_plan_display }}</strong></p>
+  <p>Vigência: {{ subscription.start_date|date:'d/m/Y H:i' }} até <strong>{{ subscription.end_date|date:'d/m/Y H:i' }}</strong></p>
+  <p>Status: {% if subscription.is_active %}<span class="badge bg-success">Ativa</span>{% else %}<span class="badge bg-danger">Expirada</span>{% endif %}</p>
+{% else %}
+  <div class="alert alert-warning">Sem assinatura vinculada.</div>
+{% endif %}
+<a class="btn btn-secondary" href="{% url 'accounts:owner_logout' %}">Sair</a>

--- a/apps/accounts/templates/accounts/partials/owner_login.html
+++ b/apps/accounts/templates/accounts/partials/owner_login.html
@@ -1,0 +1,11 @@
+<div class="row justify-content-center">
+  <div class="col-md-5">
+    <h3 class="mb-3">Login (Dono)</h3>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Entrar</button>
+    </form>
+    <hr>
+    <p class="text-muted small">Primeiro login cria automaticamente o período Free (7 dias).</p>
+  </div>
+</div>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -4,6 +4,7 @@ from . import views
 app_name = 'accounts'
 
 urlpatterns = [
+    path('', views.owner_login, name='home'),
     # Owner
     path('login/', views.owner_login, name='owner_login'),
     path('logout/', views.owner_logout, name='owner_logout'),

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -32,13 +32,21 @@ def owner_login(request):
             return redirect('accounts:owner_dashboard')
     else:
         form = OwnerLoginForm()
-    return render(request, 'accounts/owner_login.html', {'form': form})
+
+    template = 'accounts/owner_login.html'
+    if request.headers.get('HX-Request'):
+        template = 'accounts/partials/owner_login.html'
+    return render(request, template, {'form': form})
 
 @login_required
 def owner_dashboard(request):
     user = request.user
     sub = getattr(user, 'subscription', None)
-    return render(request, 'accounts/owner_dashboard.html', {'subscription': sub})
+
+    template = 'accounts/owner_dashboard.html'
+    if request.headers.get('HX-Request'):
+        template = 'accounts/partials/owner_dashboard.html'
+    return render(request, template, {'subscription': sub})
 
 @login_required
 def owner_logout(request):

--- a/apps/cadastro/forms.py
+++ b/apps/cadastro/forms.py
@@ -1,7 +1,26 @@
 from django import forms
-from .models import Loja
+from .models import Loja, Funcionario, Servico
 
 class LojaForm(forms.ModelForm):
     class Meta:
         model = Loja
         fields = ['nome', 'telefone', 'endereco', 'ativa']
+
+
+class FuncionarioForm(forms.ModelForm):
+    class Meta:
+        model = Funcionario
+        fields = ['nome', 'cargo', 'email', 'telefone', 'ativo']
+
+
+class ServicoForm(forms.ModelForm):
+    class Meta:
+        model = Servico
+        fields = [
+            'nome',
+            'descricao',
+            'duracao_minutos',
+            'preco',
+            'profissionais',
+            'ativo',
+        ]

--- a/apps/cadastro/templates/funcionario/owner_staff.html
+++ b/apps/cadastro/templates/funcionario/owner_staff.html
@@ -1,0 +1,35 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Funcionários{% endblock %}
+{% block content %}
+<h4 class="mb-3">Funcionários de {{ loja.nome }}</h4>
+<div class="row">
+  <div class="col-md-5">
+    <h5>Novo funcionário</h5>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Salvar</button>
+    </form>
+  </div>
+  <div class="col-md-7">
+    <h5>Lista</h5>
+    <table class="table table-striped">
+      <thead><tr><th>Nome</th><th>Cargo</th><th>Ações</th></tr></thead>
+      <tbody>
+        {% for func in funcionarios %}
+        <tr>
+          <td>{{ func.nome }}</td>
+          <td>{{ func.get_cargo_display }}</td>
+          <td>
+            <a class="btn btn-sm btn-secondary" hx-get="{% url 'cadastro:owner_staff_edit' loja.id func.id %}" hx-target="#content" hx-push-url="true">Editar</a>
+            <a class="btn btn-sm btn-danger" hx-get="{% url 'cadastro:owner_staff_delete' loja.id func.id %}" hx-target="#content" hx-push-url="true">Excluir</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-muted">Nenhum funcionário.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<a class="btn btn-secondary mt-3" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>
+{% endblock %}

--- a/apps/cadastro/templates/funcionario/owner_staff_confirm_delete.html
+++ b/apps/cadastro/templates/funcionario/owner_staff_confirm_delete.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Excluir Funcionário{% endblock %}
+{% block content %}
+<h4>Excluir funcionário</h4>
+<p>Tem certeza que deseja remover {{ funcionario.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_staff' loja.id %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/funcionario/owner_staff_form.html
+++ b/apps/cadastro/templates/funcionario/owner_staff_form.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Editar Funcionário{% endblock %}
+{% block content %}
+<h4 class="mb-3">Editar funcionário</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_staff' loja.id %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/funcionario/partials/owner_staff.html
+++ b/apps/cadastro/templates/funcionario/partials/owner_staff.html
@@ -1,0 +1,31 @@
+<h4 class="mb-3">Funcionários de {{ loja.nome }}</h4>
+<div class="row">
+  <div class="col-md-5">
+    <h5>Novo funcionário</h5>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Salvar</button>
+    </form>
+  </div>
+  <div class="col-md-7">
+    <h5>Lista</h5>
+    <table class="table table-striped">
+      <thead><tr><th>Nome</th><th>Cargo</th><th>Ações</th></tr></thead>
+      <tbody>
+        {% for func in funcionarios %}
+        <tr>
+          <td>{{ func.nome }}</td>
+          <td>{{ func.get_cargo_display }}</td>
+          <td>
+            <a class="btn btn-sm btn-secondary" hx-get="{% url 'cadastro:owner_staff_edit' loja.id func.id %}" hx-target="#content" hx-push-url="true">Editar</a>
+            <a class="btn btn-sm btn-danger" hx-get="{% url 'cadastro:owner_staff_delete' loja.id func.id %}" hx-target="#content" hx-push-url="true">Excluir</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-muted">Nenhum funcionário.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<a class="btn btn-secondary mt-3" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>

--- a/apps/cadastro/templates/funcionario/partials/owner_staff_confirm_delete.html
+++ b/apps/cadastro/templates/funcionario/partials/owner_staff_confirm_delete.html
@@ -1,0 +1,6 @@
+<h4>Excluir funcionário</h4>
+<p>Tem certeza que deseja remover {{ funcionario.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_staff' loja.id %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>

--- a/apps/cadastro/templates/funcionario/partials/owner_staff_form.html
+++ b/apps/cadastro/templates/funcionario/partials/owner_staff_form.html
@@ -1,0 +1,6 @@
+<h4 class="mb-3">Editar funcionário</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_staff' loja.id %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>

--- a/apps/cadastro/templates/loja/owner_shop_confirm_delete.html
+++ b/apps/cadastro/templates/loja/owner_shop_confirm_delete.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Excluir Loja{% endblock %}
+{% block content %}
+<h4>Excluir loja</h4>
+<p>Tem certeza que deseja remover {{ loja.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/loja/owner_shop_form.html
+++ b/apps/cadastro/templates/loja/owner_shop_form.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Editar Loja{% endblock %}
+{% block content %}
+<h4 class="mb-3">Editar loja</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/loja/partials/owner_shop_confirm_delete.html
+++ b/apps/cadastro/templates/loja/partials/owner_shop_confirm_delete.html
@@ -1,0 +1,6 @@
+<h4>Excluir loja</h4>
+<p>Tem certeza que deseja remover {{ loja.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>

--- a/apps/cadastro/templates/loja/partials/owner_shop_form.html
+++ b/apps/cadastro/templates/loja/partials/owner_shop_form.html
@@ -1,0 +1,6 @@
+<h4 class="mb-3">Editar loja</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>

--- a/apps/cadastro/templates/loja/partials/owner_shops.html
+++ b/apps/cadastro/templates/loja/partials/owner_shops.html
@@ -1,6 +1,3 @@
-{% extends 'accounts/base.html' %}
-{% block title %}Minhas Lojas{% endblock %}
-{% block content %}
 <div class="row">
   <div class="col-md-5">
     <h4 class="mb-3">Nova loja</h4>
@@ -17,9 +14,7 @@
         {% for loja in lojas %}
         <tr>
           <td>{{ loja.nome }}</td>
-          <td>
-            <a href="{{ loja.get_public_url request }}" target="_blank">{{ loja.get_public_url request }}</a>
-          </td>
+          <td><a href="{{ loja.get_public_url request }}" target="_blank">{{ loja.get_public_url request }}</a></td>
           <td>
             {% if loja.ativa %}
               <span class="badge bg-success">Ativa</span>
@@ -41,4 +36,3 @@
     </table>
   </div>
 </div>
-{% endblock %}

--- a/apps/cadastro/templates/servico/owner_service_confirm_delete.html
+++ b/apps/cadastro/templates/servico/owner_service_confirm_delete.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Excluir Serviço{% endblock %}
+{% block content %}
+<h4>Excluir serviço</h4>
+<p>Tem certeza que deseja remover {{ servico.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_services' loja.id %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/servico/owner_service_form.html
+++ b/apps/cadastro/templates/servico/owner_service_form.html
@@ -1,0 +1,10 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Editar Serviço{% endblock %}
+{% block content %}
+<h4 class="mb-3">Editar serviço</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_services' loja.id %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>
+{% endblock %}

--- a/apps/cadastro/templates/servico/owner_services.html
+++ b/apps/cadastro/templates/servico/owner_services.html
@@ -1,0 +1,35 @@
+{% extends 'accounts/base.html' %}
+{% block title %}Serviços{% endblock %}
+{% block content %}
+<h4 class="mb-3">Serviços de {{ loja.nome }}</h4>
+<div class="row">
+  <div class="col-md-5">
+    <h5>Novo serviço</h5>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Salvar</button>
+    </form>
+  </div>
+  <div class="col-md-7">
+    <h5>Lista</h5>
+    <table class="table table-striped">
+      <thead><tr><th>Nome</th><th>Preço</th><th>Ações</th></tr></thead>
+      <tbody>
+        {% for serv in servicos %}
+        <tr>
+          <td>{{ serv.nome }}</td>
+          <td>R$ {{ serv.preco }}</td>
+          <td>
+            <a class="btn btn-sm btn-secondary" hx-get="{% url 'cadastro:owner_service_edit' loja.id serv.id %}" hx-target="#content" hx-push-url="true">Editar</a>
+            <a class="btn btn-sm btn-danger" hx-get="{% url 'cadastro:owner_service_delete' loja.id serv.id %}" hx-target="#content" hx-push-url="true">Excluir</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-muted">Nenhum serviço.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<a class="btn btn-secondary mt-3" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>
+{% endblock %}

--- a/apps/cadastro/templates/servico/partials/owner_service_confirm_delete.html
+++ b/apps/cadastro/templates/servico/partials/owner_service_confirm_delete.html
@@ -1,0 +1,6 @@
+<h4>Excluir serviço</h4>
+<p>Tem certeza que deseja remover {{ servico.nome }}?</p>
+<form method="post">{% csrf_token %}
+  <button class="btn btn-danger" type="submit">Confirmar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_services' loja.id %}" hx-target="#content" hx-push-url="true">Cancelar</a>
+</form>

--- a/apps/cadastro/templates/servico/partials/owner_service_form.html
+++ b/apps/cadastro/templates/servico/partials/owner_service_form.html
@@ -1,0 +1,6 @@
+<h4 class="mb-3">Editar serviço</h4>
+<form method="post">{% csrf_token %}
+  {{ form.as_p }}
+  <button class="btn btn-primary" type="submit">Salvar</button>
+  <a class="btn btn-secondary" hx-get="{% url 'cadastro:owner_services' loja.id %}" hx-target="#content" hx-push-url="true">Voltar</a>
+</form>

--- a/apps/cadastro/templates/servico/partials/owner_services.html
+++ b/apps/cadastro/templates/servico/partials/owner_services.html
@@ -1,0 +1,31 @@
+<h4 class="mb-3">Serviços de {{ loja.nome }}</h4>
+<div class="row">
+  <div class="col-md-5">
+    <h5>Novo serviço</h5>
+    <form method="post">{% csrf_token %}
+      {{ form.as_p }}
+      <button class="btn btn-primary w-100" type="submit">Salvar</button>
+    </form>
+  </div>
+  <div class="col-md-7">
+    <h5>Lista</h5>
+    <table class="table table-striped">
+      <thead><tr><th>Nome</th><th>Preço</th><th>Ações</th></tr></thead>
+      <tbody>
+        {% for serv in servicos %}
+        <tr>
+          <td>{{ serv.nome }}</td>
+          <td>R$ {{ serv.preco }}</td>
+          <td>
+            <a class="btn btn-sm btn-secondary" hx-get="{% url 'cadastro:owner_service_edit' loja.id serv.id %}" hx-target="#content" hx-push-url="true">Editar</a>
+            <a class="btn btn-sm btn-danger" hx-get="{% url 'cadastro:owner_service_delete' loja.id serv.id %}" hx-target="#content" hx-push-url="true">Excluir</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-muted">Nenhum serviço.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<a class="btn btn-secondary mt-3" hx-get="{% url 'cadastro:owner_shops' %}" hx-target="#content" hx-push-url="true">Voltar</a>

--- a/apps/cadastro/urls.py
+++ b/apps/cadastro/urls.py
@@ -6,5 +6,13 @@ app_name = 'cadastro'
 
 urlpatterns = [
     path('owner/lojas/', views.owner_shops, name='owner_shops'),
+    path('owner/lojas/<int:pk>/editar/', views.owner_shop_edit, name='owner_shop_edit'),
+    path('owner/lojas/<int:pk>/excluir/', views.owner_shop_delete, name='owner_shop_delete'),
+    path('owner/lojas/<int:loja_id>/funcionarios/', views.owner_staff, name='owner_staff'),
+    path('owner/lojas/<int:loja_id>/funcionarios/<int:pk>/editar/', views.owner_staff_edit, name='owner_staff_edit'),
+    path('owner/lojas/<int:loja_id>/funcionarios/<int:pk>/excluir/', views.owner_staff_delete, name='owner_staff_delete'),
+    path('owner/lojas/<int:loja_id>/servicos/', views.owner_services, name='owner_services'),
+    path('owner/lojas/<int:loja_id>/servicos/<int:pk>/editar/', views.owner_service_edit, name='owner_service_edit'),
+    path('owner/lojas/<int:loja_id>/servicos/<int:pk>/excluir/', views.owner_service_delete, name='owner_service_delete'),
     path('<slug:slug>/', client_start_loja, name='client_start_loja'),
 ]

--- a/apps/cadastro/views.py
+++ b/apps/cadastro/views.py
@@ -3,8 +3,8 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
-from .models import Loja
-from .forms import LojaForm
+from .models import Loja, Funcionario, Servico
+from .forms import LojaForm, FuncionarioForm, ServicoForm
 
 @login_required
 def owner_shops(request):
@@ -19,12 +19,202 @@ def owner_shops(request):
             loja.owner = request.user
             loja.save()
             messages.success(request, 'Loja criada com sucesso!')
-            return redirect('loja:owner_shops')
+            return redirect('cadastro:owner_shops')
     else:
         form = LojaForm()
 
     lojas = request.user.lojas.all().order_by('-criada_em')
-    return render(request, 'loja/owner_shops.html', {
+
+    template = 'loja/owner_shops.html'
+    if request.headers.get('HX-Request'):
+        template = 'loja/partials/owner_shops.html'
+    return render(request, template, {
         'form': form,
         'lojas': lojas,
     })
+
+
+@login_required
+def owner_shop_edit(request, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=pk, owner=request.user)
+
+    if request.method == 'POST':
+        form = LojaForm(request.POST, instance=loja)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Loja atualizada com sucesso!')
+            return redirect('cadastro:owner_shops')
+    else:
+        form = LojaForm(instance=loja)
+
+    template = 'loja/owner_shop_form.html'
+    if request.headers.get('HX-Request'):
+        template = 'loja/partials/owner_shop_form.html'
+    return render(request, template, {'form': form, 'loja': loja})
+
+
+@login_required
+def owner_shop_delete(request, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=pk, owner=request.user)
+
+    if request.method == 'POST':
+        loja.delete()
+        messages.success(request, 'Loja removida com sucesso!')
+        return redirect('cadastro:owner_shops')
+
+    template = 'loja/owner_shop_confirm_delete.html'
+    if request.headers.get('HX-Request'):
+        template = 'loja/partials/owner_shop_confirm_delete.html'
+    return render(request, template, {'loja': loja})
+
+
+@login_required
+def owner_staff(request, loja_id):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+
+    if request.method == 'POST':
+        form = FuncionarioForm(request.POST)
+        if form.is_valid():
+            funcionario = form.save(commit=False)
+            funcionario.loja = loja
+            funcionario.save()
+            messages.success(request, 'Funcionário cadastrado com sucesso!')
+            return redirect('cadastro:owner_staff', loja_id=loja.id)
+    else:
+        form = FuncionarioForm()
+
+    funcionarios = loja.funcionarios.all().order_by('nome')
+
+    template = 'funcionario/owner_staff.html'
+    if request.headers.get('HX-Request'):
+        template = 'funcionario/partials/owner_staff.html'
+    return render(request, template, {
+        'loja': loja,
+        'form': form,
+        'funcionarios': funcionarios,
+    })
+
+
+@login_required
+def owner_staff_edit(request, loja_id, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+    funcionario = get_object_or_404(Funcionario, pk=pk, loja=loja)
+
+    if request.method == 'POST':
+        form = FuncionarioForm(request.POST, instance=funcionario)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Funcionário atualizado com sucesso!')
+            return redirect('cadastro:owner_staff', loja_id=loja.id)
+    else:
+        form = FuncionarioForm(instance=funcionario)
+
+    template = 'funcionario/owner_staff_form.html'
+    if request.headers.get('HX-Request'):
+        template = 'funcionario/partials/owner_staff_form.html'
+    return render(request, template, {'loja': loja, 'form': form, 'funcionario': funcionario})
+
+
+@login_required
+def owner_staff_delete(request, loja_id, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+    funcionario = get_object_or_404(Funcionario, pk=pk, loja=loja)
+
+    if request.method == 'POST':
+        funcionario.delete()
+        messages.success(request, 'Funcionário removido com sucesso!')
+        return redirect('cadastro:owner_staff', loja_id=loja.id)
+
+    template = 'funcionario/owner_staff_confirm_delete.html'
+    if request.headers.get('HX-Request'):
+        template = 'funcionario/partials/owner_staff_confirm_delete.html'
+    return render(request, template, {'loja': loja, 'funcionario': funcionario})
+
+
+@login_required
+def owner_services(request, loja_id):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+
+    if request.method == 'POST':
+        form = ServicoForm(request.POST)
+        if form.is_valid():
+            servico = form.save(commit=False)
+            servico.loja = loja
+            servico.save()
+            form.save_m2m()
+            messages.success(request, 'Serviço criado com sucesso!')
+            return redirect('cadastro:owner_services', loja_id=loja.id)
+    else:
+        form = ServicoForm()
+
+    servicos = loja.servicos.all().order_by('nome')
+
+    template = 'servico/owner_services.html'
+    if request.headers.get('HX-Request'):
+        template = 'servico/partials/owner_services.html'
+    return render(request, template, {
+        'loja': loja,
+        'form': form,
+        'servicos': servicos,
+    })
+
+
+@login_required
+def owner_service_edit(request, loja_id, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+    servico = get_object_or_404(Servico, pk=pk, loja=loja)
+
+    if request.method == 'POST':
+        form = ServicoForm(request.POST, instance=servico)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Serviço atualizado com sucesso!')
+            return redirect('cadastro:owner_services', loja_id=loja.id)
+    else:
+        form = ServicoForm(instance=servico)
+
+    template = 'servico/owner_service_form.html'
+    if request.headers.get('HX-Request'):
+        template = 'servico/partials/owner_service_form.html'
+    return render(request, template, {'loja': loja, 'form': form, 'servico': servico})
+
+
+@login_required
+def owner_service_delete(request, loja_id, pk):
+    if not getattr(request.user, 'is_owner', False):
+        return redirect('accounts:owner_login')
+
+    loja = get_object_or_404(Loja, pk=loja_id, owner=request.user)
+    servico = get_object_or_404(Servico, pk=pk, loja=loja)
+
+    if request.method == 'POST':
+        servico.delete()
+        messages.success(request, 'Serviço removido com sucesso!')
+        return redirect('cadastro:owner_services', loja_id=loja.id)
+
+    template = 'servico/owner_service_confirm_delete.html'
+    if request.headers.get('HX-Request'):
+        template = 'servico/partials/owner_service_confirm_delete.html'
+    return render(request, template, {'loja': loja, 'servico': servico})
+


### PR DESCRIPTION
## Summary
- add model forms for Loja, Funcionario and Servico
- implement HTMX-enabled CRUD views and URLs for shops, employees and services
- include templates and sidebar links to manage related records in-page

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a3be7d9ec483329e7b49a90498a038