### PR TITLE
Use htmx to create stores without page reload

### DIFF
--- a/apps/cadastro/templates/loja/owner_shops.html
+++ b/apps/cadastro/templates/loja/owner_shops.html
@@ -1,38 +1,7 @@
 {% extends 'accounts/base.html' %}
 {% block title %}Minhas Lojas{% endblock %}
 {% block content %}
-<div class="row">
-  <div class="col-md-5">
-    <h4 class="mb-3">Nova loja</h4>
-    <form method="post">{% csrf_token %}
-      {{ form.as_p }}
-      <button class="btn btn-primary w-100" type="submit">Criar loja</button>
-    </form>
-  </div>
-  <div class="col-md-7">
-    <h4 class="mb-3">Lojas cadastradas</h4>
-    <table class="table table-striped">
-      <thead><tr><th>Nome</th><th>Link público</th><th>Status</th></tr></thead>
-      <tbody>
-        {% for loja in lojas %}
-        <tr>
-          <td>{{ loja.nome }}</td>
-          <td>
-            <a href="{{ loja.get_public_url request }}" target="_blank">{{ loja.get_public_url request }}</a>
-          </td>
-          <td>
-            {% if loja.ativa %}
-              <span class="badge bg-success">Ativa</span>
-            {% else %}
-              <span class="badge bg-secondary">Inativa</span>
-            {% endif %}
-          </td>
-        </tr>
-        {% empty %}
-        <tr><td colspan="3" class="text-muted">Nenhuma loja ainda.</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+<div id="owner-shops-container">
+  {% include 'loja/partials/owner_shops.html' %}
 </div>
 {% endblock %}

--- a/apps/cadastro/templates/loja/partials/owner_shops.html
+++ b/apps/cadastro/templates/loja/partials/owner_shops.html
@@ -1,7 +1,10 @@
 <div class="row">
   <div class="col-md-5">
     <h4 class="mb-3">Nova loja</h4>
-    <form method="post">{% csrf_token %}
+    <form hx-post="{% url 'cadastro:owner_shops' %}"
+          hx-target="#owner-shops-container"
+          hx-swap="innerHTML"
+          method="post">{% csrf_token %}
       {{ form.as_p }}
       <button class="btn btn-primary w-100" type="submit">Criar loja</button>
     </form>

--- a/apps/cadastro/views.py
+++ b/apps/cadastro/views.py
@@ -1,13 +1,14 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse
+from django.shortcuts import redirect, render
 
-from .models import Loja
 from .forms import LojaForm
+from .models import Loja
+
 
 @login_required
 def owner_shops(request):
+    """Lista e cria lojas do proprietário sem recarregar a página."""
     # Apenas Dono
     if not getattr(request.user, 'is_owner', False):
         return redirect('accounts:owner_login')
@@ -19,16 +20,14 @@ def owner_shops(request):
             loja.owner = request.user
             loja.save()
             messages.success(request, 'Loja criada com sucesso!')
-            return redirect('cadastro:owner_shops')
+            form = LojaForm()
     else:
         form = LojaForm()
 
     lojas = request.user.lojas.all().order_by('-criada_em')
 
-    template = 'loja/owner_shops.html'
+    context = {'form': form, 'lojas': lojas}
+
     if request.headers.get('HX-Request'):
-        template = 'loja/partials/owner_shops.html'
-    return render(request, template, {
-        'form': form,
-        'lojas': lojas,
-    })
+        return render(request, 'loja/partials/owner_shops.html', context)
+    return render(request, 'loja/owner_shops.html', context)


### PR DESCRIPTION
## Summary
- Render owner shops form and list via htmx to prevent page refresh on submit
- Handle htmx requests in owner_shops view and reset form after successful creation

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c4293d188332ac786c28dffd0aab