### PR TITLE
Handle plan limit errors on store and employee creation

### DIFF
--- a/apps/cadastro/forms.py
+++ b/apps/cadastro/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.urls import reverse
 from .models import Loja, Funcionario, Servico
-from apps.accounts.models import PlanInfo
+from apps.accounts.models import Plan, PlanInfo
 
 
 class LojaForm(forms.ModelForm):

--- a/apps/cadastro/views.py
+++ b/apps/cadastro/views.py
@@ -92,6 +92,9 @@ def owner_shops(request):
 
             return redirect('cadastro:owner_shops')
         else:
+            # adiciona mensagens de erro (ex.: limite do plano)
+            for err in form.non_field_errors():
+                messages.error(request, err)
             # Form inválido → se for HTMX, devolve parcial com erros
             if request.headers.get('HX-Request') and target != 'content':
                 lojas = request.user.lojas.all().order_by('-criada_em')
@@ -144,6 +147,8 @@ def funcionarios(request):
                 return render(request, 'cadastro/partials/funcionarios.html', ctx)
             return redirect(f"{request.path}?loja_filtro={loja.id}")
         # inválido
+        for err in form.non_field_errors():
+            messages.error(request, err)
         qs = loja.funcionarios.order_by('nome')
         ctx = {'lojas': lojas_qs, 'loja': loja, 'form': form, 'funcionarios': qs}
         if request.headers.get('HX-Request') and target != 'content':


### PR DESCRIPTION
## Summary
- Display flash error messages when exceeding store or employee limits
- Import plan enum in forms for plan limit validation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e7641bc8332866a3a1914fd4f54