### PR TITLE
Enforce login redirect for unauthenticated users

### DIFF
--- a/apps/accounts/middleware.py
+++ b/apps/accounts/middleware.py
@@ -1,8 +1,34 @@
 from django.shortcuts import redirect
 from django.urls import reverse
 
+
+class LoginRequiredMiddleware:
+    """Redireciona visitantes não autenticados para a tela de login."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        path = request.path
+        allowed = (
+            reverse('accounts:owner_login'),
+            reverse('accounts:owner_logout'),
+            reverse('accounts:client_start_loja'),
+            reverse('accounts:client_verify'),
+        )
+        if (
+            not request.user.is_authenticated
+            and path not in allowed
+            and not path.startswith('/static/')
+            and not path.startswith('/admin/')
+        ):
+            return redirect('accounts:owner_login')
+        return self.get_response(request)
+
+
 class SubscriptionRequiredMiddleware:
     """Restringe páginas do Owner quando a assinatura estiver expirada."""
+
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/barber/settings.py
+++ b/barber/settings.py
@@ -52,6 +52,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
+    'apps.accounts.middleware.LoginRequiredMiddleware',
     'apps.accounts.middleware.SubscriptionRequiredMiddleware',
 
 ]


### PR DESCRIPTION
## Summary
- add LoginRequiredMiddleware to push unauthenticated visitors to login
- register middleware in settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68aa2b4e79ec83329c3df62bed275fbf