### PR TITLE
Fix funcionario action buttons

### DIFF
--- a/apps/cadastro/templates/cadastro/funcionarios.html
+++ b/apps/cadastro/templates/cadastro/funcionarios.html
@@ -28,7 +28,7 @@
 <div class="table-responsive">
   <table class="table table-striped align-middle">
     <thead>
-      <tr><th>Nome</th><th>Cargo</th><th>E-mail</th><th>Telefone</th><th>Status</th></tr>
+      <tr><th>Nome</th><th>Cargo</th><th>E-mail</th><th>Telefone</th><th>Status</th><th class="text-end">Ações</th></tr>
     </thead>
     {% include 'cadastro/partials/funcionarios.html' %}
   </table>

--- a/apps/cadastro/templates/cadastro/partials/funcionarios.html
+++ b/apps/cadastro/templates/cadastro/partials/funcionarios.html
@@ -12,20 +12,22 @@
     <td class="text-end">
       <button
         class="btn btn-sm btn-outline-primary"
+        data-bs-toggle="modal"
+        data-bs-target="#modalFuncionario"
         hx-get="{% url 'cadastro:funcionario_edit' f.pk %}"
         hx-target="#modalFuncionario .modal-content"
         hx-swap="innerHTML"
-        hx-on="htmx:afterOnLoad: (function(){ const m=document.getElementById('modalFuncionario'); if(m){ bootstrap.Modal.getOrCreateInstance(m).show(); } })()"
       >
         Editar
       </button>
 
       <button
         class="btn btn-sm btn-outline-danger"
+        data-bs-toggle="modal"
+        data-bs-target="#modalFuncionario"
         hx-get="{% url 'cadastro:funcionario_delete' f.pk %}"
         hx-target="#modalFuncionario .modal-content"
         hx-swap="innerHTML"
-        hx-on="htmx:afterOnLoad: (function(){ const m=document.getElementById('modalFuncionario'); if(m){ bootstrap.Modal.getOrCreateInstance(m).show(); } })()"
       >
         Excluir
       </button>


### PR DESCRIPTION
## Summary
- add actions column to employee list header
- ensure edit/delete buttons open modal via bootstrap attributes

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68af7b4411608332aad475437a117957