### PR TITLE
Add no-show flow for appointments

### DIFF
--- a/apps/accounts/templates/accounts/partials/client_dashboard.html
+++ b/apps/accounts/templates/accounts/partials/client_dashboard.html
@@ -31,7 +31,9 @@
           {% endfor %}
         </td>
         <td>
-          {% if ag.confirmado %}
+          {% if ag.no_show %}
+            <span class="badge bg-danger">Não compareceu</span>
+          {% elif ag.confirmado %}
             <span class="badge bg-success">Confirmado</span>
           {% else %}
             <span class="badge bg-warning text-dark">Pendente</span>

--- a/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
+++ b/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
@@ -52,7 +52,7 @@
                       <span class="text-muted">—</span>
                     {% endif %}
                   </td>
-                  <td>{% if a.confirmado %}Confirmado{% else %}Pendente{% endif %}</td>
+                  <td>{% if a.no_show %}Não compareceu{% elif a.confirmado %}Confirmado{% else %}Pendente{% endif %}</td>
                   <td>
                     <button class="btn btn-sm btn-outline-success"
                             data-bs-toggle="modal"
@@ -110,7 +110,7 @@
                       <span class="text-muted">—</span>
                     {% endif %}
                   </td>
-                  <td>{% if a.confirmado %}Confirmado{% else %}Pendente{% endif %}</td>
+                  <td>{% if a.no_show %}Não compareceu{% elif a.confirmado %}Confirmado{% else %}Pendente{% endif %}</td>
                   <td><span class="text-muted">—</span></td>
                 </tr>
                 {% empty %}

--- a/apps/appointments/admin.py
+++ b/apps/appointments/admin.py
@@ -12,9 +12,10 @@ class AgendamentoAdmin(admin.ModelAdmin):
         "data",
         "hora",
         "confirmado",
+        "no_show",
         "criado_em",
     )
-    list_filter = ("loja", "funcionario", "servicos", "confirmado", "data")
+    list_filter = ("loja", "funcionario", "servicos", "confirmado", "no_show", "data")
     search_fields = (
         "cliente__full_name",
         "cliente__email",
@@ -26,7 +27,7 @@ class AgendamentoAdmin(admin.ModelAdmin):
     ordering = ("-data", "-hora")
     date_hierarchy = "data"
     autocomplete_fields = ("cliente", "loja", "servicos")
-    list_editable = ("confirmado",)
+    list_editable = ("confirmado", "no_show")
 
     def lista_servicos(self, obj):
         return ", ".join(s.nome for s in obj.servicos.all()[:3]) + (

--- a/apps/appointments/migrations/0006_agendamento_no_show.py
+++ b/apps/appointments/migrations/0006_agendamento_no_show.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("appointments", "0005_agendamento_observacao"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agendamento",
+            name="no_show",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apps/appointments/models.py
+++ b/apps/appointments/models.py
@@ -21,6 +21,7 @@ class Agendamento(models.Model):
 
     criado_em = models.DateTimeField(auto_now_add=True)
     confirmado = models.BooleanField(default=False)
+    no_show = models.BooleanField(default=False)
 
     class FormaPagamento(models.TextChoices):
         PIX = "pix", "PIX"

--- a/apps/appointments/templates/appointments/partials/finalizar_agendamento.html
+++ b/apps/appointments/templates/appointments/partials/finalizar_agendamento.html
@@ -60,6 +60,11 @@
 
     <div class="d-flex justify-content-end gap-2">
       <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+      <button type="button"
+              class="btn btn-outline-danger"
+              hx-get="{% url 'appointments:marcar_no_show' agendamento.pk %}"
+              hx-target="#modalShell .modal-content"
+              hx-swap="innerHTML">Não compareceu</button>
       <button type="submit" class="btn btn-primary">Finalizar</button>
     </div>
   </form>

--- a/apps/appointments/templates/appointments/partials/no_show_confirm.html
+++ b/apps/appointments/templates/appointments/partials/no_show_confirm.html
@@ -1,0 +1,19 @@
+<div class="modal-header">
+  <h5 class="modal-title text-danger">Marcar como não compareceu</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+</div>
+<div class="modal-body">
+  <p>Tem certeza que deseja marcar <strong>{{ agendamento.cliente.full_name }}</strong> como "não compareceu"?</p>
+  <form method="post"
+        hx-post="{% url 'appointments:marcar_no_show' agendamento.pk %}"
+        hx-target="#modalShell .modal-content"
+        hx-swap="innerHTML"
+        hx-include="#filtro-agendamentos"
+        hx-on="htmx:afterRequest: if (event.detail.xhr.status < 400) { try { bootstrap.Modal.getOrCreateInstance(document.getElementById('modalShell')).hide(); } catch(e) {} }">
+    {% csrf_token %}
+    <div class="d-flex justify-content-end gap-2">
+      <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+      <button type="submit" class="btn btn-danger">Confirmar</button>
+    </div>
+  </form>
+</div>

--- a/apps/appointments/urls.py
+++ b/apps/appointments/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("agendar/datahora/", views.agendamento_datahora, name="agendamento_datahora"),
     path("agendar/confirmacao/<int:agendamento_id>/", views.agendamento_confirmacao, name="agendamento_confirmacao"),
     path("agendamentos/<int:pk>/finalizar/", views.finalizar_agendamento, name="finalizar_agendamento"),
+    path("agendamentos/<int:pk>/no-show/", views.marcar_no_show, name="marcar_no_show"),
 ]


### PR DESCRIPTION
## Summary
- allow marking appointments as no-show with confirmation modal
- store no-show flag on appointments and show status in dashboards
- expose no-show field in admin

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b506d496a483329b7c072735b125a3