### PR TITLE
Add modal to create appointments

### DIFF
--- a/apps/accounts/templates/accounts/owner_home.html
+++ b/apps/accounts/templates/accounts/owner_home.html
@@ -3,6 +3,17 @@
 
 {% block content %}
 
+<div class="mb-3 text-end">
+  <button class="btn btn-primary"
+          data-bs-toggle="modal"
+          data-bs-target="#modalShellLarge"
+          hx-get="{% url 'accounts:owner_criar_atendimento' %}"
+          hx-target="#modalShellLarge .modal-content"
+          hx-swap="innerHTML">
+    Criar atendimento
+  </button>
+</div>
+
 <div id="owner-home">
   {# Conteúdo dinâmico: renderizamos o parcial aqui #}
   {% include 'accounts/partials/owner_home.html' %}

--- a/apps/accounts/templates/accounts/partials/criar_atendimento_modal.html
+++ b/apps/accounts/templates/accounts/partials/criar_atendimento_modal.html
@@ -1,0 +1,47 @@
+<div class="modal-header">
+  <h5 class="modal-title">Criar atendimento</h5>
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+  <form id="formCriarAtendimento">
+    <div class="mb-3">
+      <label for="cliente" class="form-label">Cliente</label>
+      <div class="input-group">
+        <select class="form-select" id="cliente" name="cliente">
+          {% for c in clientes %}
+            <option value="{{ c.user.id }}">{{ c.user.full_name }}</option>
+          {% endfor %}
+        </select>
+        <a href="{% url 'cadastro:clientes' %}" target="_blank" class="btn btn-outline-secondary">Adicionar</a>
+      </div>
+    </div>
+    <div class="mb-3">
+      <label for="funcionario" class="form-label">Funcionário</label>
+      <select class="form-select" id="funcionario" name="funcionario">
+        {% for f in funcionarios %}
+          <option value="{{ f.id }}">{{ f.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="servico" class="form-label">Serviço</label>
+      <select class="form-select" id="servico" name="servico">
+        {% for s in servicos %}
+          <option value="{{ s.id }}">{{ s.nome }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="mb-3">
+      <label for="slot" class="form-label">Horário</label>
+      <select class="form-select" id="slot" name="slot">
+        {% for s in slots %}
+          <option value="{{ s|date:'H:i' }}">{{ s|date:'H:i' }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+  <button type="button" class="btn btn-primary">Salvar</button>
+</div>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('logout/', views.owner_logout, name='owner_logout'),
     path('home/', views.owner_home, name='owner_home'),
     path("home/agendamentos/", views.owner_home_agendamentos, name="owner_home_agendamentos"),
+    path("home/criar-atendimento/", views.owner_criar_atendimento, name="owner_criar_atendimento"),
     path("sobre/", views.owner_sobre, name="owner_sobre"),
 
     # Cliente (OTP)


### PR DESCRIPTION
## Summary
- add "Criar atendimento" button on owner dashboard
- provide modal with client, employee, service and time selects
- expose view and URL to render modal contents

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b634f2f02c8332b7c555c9713533f4