### PR TITLE
Reopen schedule modal after adding client

### DIFF
--- a/apps/accounts/templates/accounts/index.html
+++ b/apps/accounts/templates/accounts/index.html
@@ -252,6 +252,16 @@
     document.body.addEventListener("htmx:syntax:error", function(evt) {
       console.error("HTMX target error:", evt.detail);
     });
+
+    document.body.addEventListener('cliente-adicionado', function () {
+      const sm = bootstrap.Modal.getInstance(document.getElementById('modalShell'));
+      if (sm) sm.hide();
+    });
+
+    document.getElementById('modalShell').addEventListener('hidden.bs.modal', function () {
+      const lg = bootstrap.Modal.getOrCreateInstance(document.getElementById('modalShellLarge'));
+      if (lg) lg.show();
+    });
   </script>
 </body>
 

--- a/apps/accounts/templates/accounts/partials/cliente_form_modal.html
+++ b/apps/accounts/templates/accounts/partials/cliente_form_modal.html
@@ -6,8 +6,7 @@
   <form id="formAddCliente"
         hx-post="{% url 'accounts:owner_add_cliente' %}"
         hx-target="#modalShell .modal-content"
-        hx-swap="innerHTML"
-        hx-on="htmx:afterRequest: if (event.detail.xhr.status < 400) { try { var sm=bootstrap.Modal.getOrCreateInstance(document.getElementById('modalShell')); sm.hide(); bootstrap.Modal.getOrCreateInstance(document.getElementById('modalShellLarge')).show(); } catch(e) {} }">
+        hx-swap="innerHTML">
     {% csrf_token %}
     <div class="row g-2">
       <div class="col-md-4">
@@ -40,10 +39,3 @@
     </div>
   </form>
 </div>
-
-<script>
-  document.getElementById('modalShell').addEventListener('hidden.bs.modal', function () {
-    var lg = bootstrap.Modal.getOrCreateInstance(document.getElementById('modalShellLarge'));
-    if (lg) { lg.show(); }
-  }, { once: true });
-</script>

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -202,6 +202,7 @@ def owner_add_cliente(request):
             resp['HX-Retarget'] = '#cliente'
             resp['HX-Reswap'] = 'beforeend'
             resp['HX-Reselect'] = f'#cliente option[value="{user.id}"]'
+            resp['HX-Trigger'] = 'cliente-adicionado'
             return resp
         resp = render(request, 'accounts/partials/cliente_form_modal.html', {'cliente_form': form}, status=422)
         resp['HX-Retarget'] = '#modalShell .modal-content'


### PR DESCRIPTION
## Summary
- Ensure adding a new client closes the client modal and reopens the scheduling modal
- Streamline client creation modal script

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6443960f48332a1033de73b7e808f