### PR TITLE
Handle empty weekly schedule forms for employees

### DIFF
--- a/apps/cadastro/tests.py
+++ b/apps/cadastro/tests.py
@@ -1,3 +1,49 @@
+from datetime import time
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Loja, Funcionario
+from .views import _agenda_formset
+
+
+class AgendaSemanalFormsetTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user(
+            email="owner@example.com", password="123", is_owner=True
+        )
+        self.loja = Loja.objects.create(owner=self.owner, nome="Loja Teste")
+
+    def test_salva_apenas_dias_preenchidos(self):
+        """Formset deve salvar somente os dias que possuem horários"""
+        func_inst = Funcionario(loja=self.loja, nome="Temp")
+        data = {
+            "agenda-TOTAL_FORMS": "7",
+            "agenda-INITIAL_FORMS": "0",
+            "agenda-MIN_NUM_FORMS": "0",
+            "agenda-MAX_NUM_FORMS": "7",
+        }
+        for i in range(7):
+            data[f"agenda-{i}-weekday"] = str(i)
+        data.update(
+            {
+                "agenda-0-inicio": "09:00",
+                "agenda-0-fim": "18:00",
+                "agenda-0-ativo": "on",
+            }
+        )
+
+        formset = _agenda_formset(func_inst, data)
+        self.assertTrue(formset.is_valid())
+
+        func = Funcionario.objects.create(loja=self.loja, nome="Bob")
+        formset.instance = func
+        formset.save()
+
+        ags = func.agendas_semanais.all()
+        self.assertEqual(ags.count(), 1)
+        ag = ags.first()
+        self.assertEqual(ag.weekday, 0)
+        self.assertEqual(ag.inicio, time(9, 0))
+        self.assertEqual(ag.fim, time(18, 0))

--- a/apps/cadastro/views.py
+++ b/apps/cadastro/views.py
@@ -31,6 +31,15 @@ def _get_loja_ativa(request, lojas_qs):
 def _agenda_formset(instance, data=None):
     """Cria formset da agenda semanal preenchendo os dias faltantes."""
     formset = FuncionarioAgendaSemanalFormSet(data=data, instance=instance, prefix="agenda")
+
+    # Ignora formulários sem horários de início/fim na validação/salvamento
+    if data:
+        for form in formset.forms:
+            inicio = form.data.get(f"{form.prefix}-inicio")
+            fim = form.data.get(f"{form.prefix}-fim")
+            if not inicio and not fim:
+                form.empty_permitted = True
+
     usados = {f.instance.weekday for f in formset.initial_forms if f.instance.pk}
     restantes = [d for d in range(7) if d not in usados]
     for form, dia in zip(formset.extra_forms, restantes):


### PR DESCRIPTION
## Summary
- Ignore empty agenda forms when saving employee schedules
- Add regression test ensuring only filled days are stored

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b7a009118c8332b8c35507b3c0929c