### PR TITLE
Fix professional selection after store change

### DIFF
--- a/apps/cadastro/templates/cadastro/partials/servico_form.html
+++ b/apps/cadastro/templates/cadastro/partials/servico_form.html
@@ -191,19 +191,22 @@
 
     <script>
     (function(){
-      // Escopa ao modal aberto (editar)
-      const modal = document.getElementById('modalServicoOps') || document.getElementById('modalServico');
-      if (!modal) return;
-      modal.querySelectorAll('.prof-chips label.btn').forEach(label => {
-        const input = label.querySelector('input.profissional-check');
-        if (!input) return;
-        const sync = () => label.classList.toggle('active', input.checked);
-        // Estado inicial
-        sync();
-        // Mudou? atualiza
-        input.addEventListener('change', sync);
-        // Clique em qualquer lugar do chip marca/desmarca (input está dentro, então já funciona)
-      });
+      function initProfChips() {
+        const modal = document.getElementById('modalServicoOps') || document.getElementById('modalServico');
+        if (!modal) return;
+        modal.querySelectorAll('.prof-chips label.btn').forEach(label => {
+          const input = label.querySelector('input.profissional-check');
+          if (!input) return;
+          const sync = () => label.classList.toggle('active', input.checked);
+          sync();
+          input.addEventListener('change', sync);
+        });
+      }
+      if (window.htmx) {
+        htmx.onLoad(() => initProfChips());
+      } else {
+        initProfChips();
+      }
     })();
     </script>
   </div>


### PR DESCRIPTION
## Summary
- Ensure professional chips are reinitialized after swapping service form content so selecting professionals works after changing store

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django==5.2.5` *(fails: Could not find a version that satisfies the requirement django==5.2.5 (proxy 403))*

------
https://chatgpt.com/codex/tasks/task_e_68be186501848332bfdab9c7aade2af0