### PR TITLE
Fix HTMX swap error on home page

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -132,8 +132,9 @@ def owner_home(request):
         'agendamentos_hoje': agendamentos,
         'no_show_hoje': no_show,
     }
-    target = request.headers.get('HX-Target')
-    if request.headers.get('HX-Request') and target != 'content':
+    hx_target = request.headers.get('HX-Target')
+    hx_select = request.headers.get('HX-Select')
+    if request.headers.get('HX-Request') and not (hx_target == 'content' or hx_select == '#content'):
         return render(request, 'accounts/partials/owner_home.html', ctx)
     return render(request, 'accounts/owner_home.html', ctx)
 


### PR DESCRIPTION
## Summary
- ensure owner home view returns a full template when `HX-Target` or `HX-Select` indicate the `#content` wrapper

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c7535f452883328699640331f10d29