### PR TITLE
Add appointment history view with pagination

### DIFF
--- a/apps/accounts/templates/accounts/index.html
+++ b/apps/accounts/templates/accounts/index.html
@@ -90,6 +90,20 @@
                 <span class="hide-menu">Relatórios</span>
               </a>
             </li>
+            <li class="sidebar-item">
+              <a
+                aria-expanded="false"
+                class="sidebar-link"
+                href="{% url 'accounts:owner_historico' %}"
+                hx-get="{% url 'accounts:owner_historico' %}"
+                hx-target="#content"
+                hx-select="#content"
+                hx-swap="outerHTML"
+                hx-push-url="true">
+                <i class="ti ti-history"></i>
+                <span class="hide-menu">Histórico</span>
+              </a>
+            </li>
             <!-- ---------------------------------- -->
             <!-- Cadastros -->
             <!-- ---------------------------------- -->

--- a/apps/accounts/templates/accounts/owner_historico.html
+++ b/apps/accounts/templates/accounts/owner_historico.html
@@ -1,0 +1,8 @@
+{% extends 'accounts/index.html' %}
+{% block title %}Histórico de Atendimentos{% endblock %}
+
+{% block content %}
+<div id="owner-historico">
+  {% include 'accounts/partials/owner_historico.html' %}
+</div>
+{% endblock %}

--- a/apps/accounts/templates/accounts/partials/owner_historico.html
+++ b/apps/accounts/templates/accounts/partials/owner_historico.html
@@ -1,0 +1,68 @@
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Data de agendamento</th>
+      <th>Data de atendimento</th>
+      <th>Cliente</th>
+      <th>Serviços</th>
+      <th>Valor</th>
+      <th>Desconto?</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for ag in page_obj %}
+    <tr>
+      <td>{{ ag.criado_em|date:"d/m/Y H:i" }}</td>
+      <td>{{ ag.data|date:"d/m/Y" }} {{ ag.hora|time:"H:i" }}</td>
+      <td>{{ ag.cliente.full_name }}</td>
+      <td>
+        {% for s in ag.servicos.all %}{% if not forloop.first %}, {% endif %}{{ s.nome }}{% endfor %}
+      </td>
+      <td>{% if ag.valor_final %}R$ {{ ag.valor_final }}{% else %}-{% endif %}</td>
+      <td>{% if ag.teve_desconto %}Sim{% else %}Não{% endif %}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="6">Nenhum atendimento encontrado.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<nav aria-label="Paginação">
+  <ul class="pagination">
+    {% if page_obj.has_previous %}
+      <li class="page-item">
+        <a class="page-link"
+           hx-get="{% url 'accounts:owner_historico' %}?page={{ page_obj.previous_page_number }}"
+           hx-target="#owner-historico"
+           hx-select="#owner-historico"
+           hx-swap="outerHTML">&laquo;</a>
+      </li>
+    {% else %}
+      <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+    {% endif %}
+
+    {% for i in page_obj.paginator.page_range %}
+      <li class="page-item {% if page_obj.number == i %}active{% endif %}">
+        <a class="page-link"
+           hx-get="{% url 'accounts:owner_historico' %}?page={{ i }}"
+           hx-target="#owner-historico"
+           hx-select="#owner-historico"
+           hx-swap="outerHTML">{{ i }}</a>
+      </li>
+    {% endfor %}
+
+    {% if page_obj.has_next %}
+      <li class="page-item">
+        <a class="page-link"
+           hx-get="{% url 'accounts:owner_historico' %}?page={{ page_obj.next_page_number }}"
+           hx-target="#owner-historico"
+           hx-select="#owner-historico"
+           hx-swap="outerHTML">&raquo;</a>
+      </li>
+    {% else %}
+      <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+    {% endif %}
+  </ul>
+</nav>

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('logout/', views.owner_logout, name='owner_logout'),
     path('home/', views.owner_home, name='owner_home'),
     path('home/dashboard/', views.owner_dashboard, name='owner_dashboard'),
+    path('home/historico/', views.owner_historico, name='owner_historico'),
     path("home/agendamentos/", views.owner_home_agendamentos, name="owner_home_agendamentos"),
     path("home/criar-atendimento/", views.owner_criar_atendimento, name="owner_criar_atendimento"),
     path("home/criar-atendimento/add-cliente/", views.owner_add_cliente, name="owner_add_cliente"),


### PR DESCRIPTION
## Summary
- add menu link and view for owners to browse appointment history
- implement paginated appointment history table template

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68c76e9231ac8332a2ff39d547d9e92c