### PR TITLE
Atualiza cartões da home ao filtrar loja

### DIFF
--- a/apps/accounts/templates/accounts/owner_home.html
+++ b/apps/accounts/templates/accounts/owner_home.html
@@ -19,6 +19,7 @@
 <div id="owner-home"
      hx-get="{% url 'accounts:owner_home' %}"
      hx-trigger="reload-owner-home from:body"
+     hx-vals="js: event && event.detail && event.detail.loja_filtro ? { loja_filtro: event.detail.loja_filtro } : {}"
      hx-target="this"
      hx-swap="innerHTML">
   {# Conteúdo dinâmico: renderizamos o parcial aqui #}

--- a/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
+++ b/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
@@ -20,7 +20,7 @@
                 hx-select="#agendamentos-section"
                 hx-swap="outerHTML"
                 hx-trigger="change"
-                hx-on="htmx:afterSwap: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { lojaId: this.value } }))">
+                hx-on="change: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { loja_filtro: this.value } }))">
           {% for l in lojas %}
             <option value="{{ l.id }}" {% if loja and l.id == loja.id %}selected{% endif %}>{{ l.nome }}</option>
           {% endfor %}

--- a/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
+++ b/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
@@ -19,7 +19,8 @@
                 hx-target="#agendamentos-section"
                 hx-select="#agendamentos-section"
                 hx-swap="outerHTML"
-                hx-trigger="change">
+                hx-trigger="change"
+                hx-on="htmx:afterSwap: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { lojaId: this.value } }))">
           {% for l in lojas %}
             <option value="{{ l.id }}" {% if loja and l.id == loja.id %}selected{% endif %}>{{ l.nome }}</option>
           {% endfor %}

--- a/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
+++ b/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
@@ -20,7 +20,7 @@
                 hx-select="#agendamentos-section"
                 hx-swap="outerHTML"
                 hx-trigger="change"
-                hx-on="htmx:afterSwap: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { loja_filtro: this.value } }))">
+                onchange="document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { loja_filtro: this.value } }))">
           {% for l in lojas %}
             <option value="{{ l.id }}" {% if loja and l.id == loja.id %}selected{% endif %}>{{ l.nome }}</option>
           {% endfor %}

--- a/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
+++ b/apps/accounts/templates/accounts/partials/owner_home_agendamentos.html
@@ -20,7 +20,7 @@
                 hx-select="#agendamentos-section"
                 hx-swap="outerHTML"
                 hx-trigger="change"
-                hx-on="change: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { loja_filtro: this.value } }))">
+                hx-on="htmx:afterSwap: document.body.dispatchEvent(new CustomEvent('reload-owner-home', { detail: { loja_filtro: this.value } }))">
           {% for l in lojas %}
             <option value="{{ l.id }}" {% if loja and l.id == loja.id %}selected{% endif %}>{{ l.nome }}</option>
           {% endfor %}

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -122,7 +122,7 @@ def owner_login(request):
 @subscription_required
 def owner_home(request):
     sub = getattr(request.user, 'subscription', None)
-    today = timezone.now().date()
+    today = timezone.localdate()
 
     lojas = request.user.lojas.order_by('nome')
     loja_id = request.GET.get('loja_filtro') or request.session.get('loja_filtro')

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -123,7 +123,17 @@ def owner_login(request):
 def owner_home(request):
     sub = getattr(request.user, 'subscription', None)
     today = timezone.now().date()
-    base = Agendamento.objects.filter(loja__owner=request.user, data=today)
+
+    lojas = request.user.lojas.order_by('nome')
+    loja_id = request.GET.get('loja_filtro') or request.session.get('loja_filtro')
+    loja = lojas.filter(id=loja_id).first() if loja_id else lojas.first()
+
+    if loja:
+        request.session['loja_filtro'] = loja.id
+        base = Agendamento.objects.filter(loja=loja, data=today)
+    else:
+        base = Agendamento.objects.filter(loja__owner=request.user, data=today)
+
     faturado = base.filter(confirmado=True, valor_final__isnull=False).aggregate(total=Sum('valor_final'))['total'] or 0
     agendamentos = base.count()
     no_show = base.filter(no_show=True).count()
@@ -132,6 +142,7 @@ def owner_home(request):
         'faturado_hoje': faturado,
         'agendamentos_hoje': agendamentos,
         'no_show_hoje': no_show,
+        'loja': loja,
     }
     target = request.headers.get('HX-Target')
     if request.headers.get('HX-Request') and target != 'content':


### PR DESCRIPTION
## Summary
- envia um evento HTMX ao trocar a loja nos agendamentos para recarregar os cards da home
- ajusta a view `owner_home` para aplicar o filtro de loja compartilhado com os agendamentos

## Testing
- `python manage.py test` *(falha: módulo Django indisponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68cb533957b48332a8ea850291f6d92c